### PR TITLE
Artifact Types List Endpoint

### DIFF
--- a/lib/prodops/artifact_type.ex
+++ b/lib/prodops/artifact_type.ex
@@ -1,0 +1,32 @@
+defmodule ProdopsEx.ArtifactType do
+  @moduledoc """
+  Handles artifact type operations for the ProdOps API.
+  """
+  alias ProdopsEx.Client
+  alias ProdopsEx.Config
+
+  @base_path "/api/v1/artifact_types"
+
+  @doc """
+  Returns a list of all artifact types for a given team
+
+  ## Examples
+
+      iex> ProdopsEx.ArtifactType.list_artifact_types(%ProdopsEx.Config{bearer_token: "your_api_key_here"})
+      {:ok, %{status: "ok", response: %{ "artifact_types": [
+            {
+                "slug": "story",
+                "name": "Story",
+                "description": "This is a story"
+            }
+        ]}}}
+  """
+  @spec list(%Config{}) :: {:ok, map} | {:error, any}
+  def list(%Config{} = config) do
+    Client.api_get(url(config), [], config)
+  end
+
+  defp url(%Config{} = config) do
+    config.api_url <> @base_path
+  end
+end

--- a/lib/prodops/client.ex
+++ b/lib/prodops/client.ex
@@ -59,4 +59,28 @@ defmodule ProdopsEx.Client do
     |> post(body, request_headers(config), request_options(config))
     |> handle_response()
   end
+
+  def query_params(request_options, [_ | _] = params) do
+    # The `request_options` may or may not be present, but the `params` are.
+    # Therefore we can guarantee to return a non-empty keyword list, so we cam
+    # modify the `request_options` unconditionnaly.
+    request_options
+    |> List.wrap()
+    |> Keyword.merge([params: params], fn :params, old_params, new_params ->
+      Keyword.merge(old_params, new_params)
+    end)
+  end
+
+  def query_params(request_options, _params), do: request_options
+
+  def api_get(path, params \\ [], config) do
+    request_options =
+      config
+      |> request_options()
+      |> query_params(params)
+
+    path
+    |> get(request_headers(config), request_options)
+    |> handle_response()
+  end
 end

--- a/lib/prodops_ex.ex
+++ b/lib/prodops_ex.ex
@@ -3,6 +3,7 @@ defmodule ProdopsEx do
   Documentation for `ProdopsEx`.
   """
 
+  alias ProdopsEx.ArtifactType
   alias ProdopsEx.Validate
 
   @doc """
@@ -26,5 +27,34 @@ defmodule ProdopsEx do
   """
   def validate_api_key(config) do
     Validate.validate_api_key(config)
+  end
+
+  @doc """
+  Returns a list of all artifact types for a given team
+
+  ## Parameters
+
+  - `config`: The configuration map containing the API key and endpoint URL.
+
+  ## Example
+  ```elixir
+  ProdopsEx.list_artifact_types(
+    %ProdopsEx.Config{
+      bearer_token: "your_api_key_here",
+    }
+  )
+  ```
+
+  ## Returns
+  {:ok, %{status: "ok", response: %{ "artifact_types": [
+            {
+                "slug": "story",
+                "name": "Story",
+                "description": "This is a story"
+            }
+  ]}}}
+  """
+  def list_artifact_types(config) do
+    ArtifactType.list(config)
   end
 end


### PR DESCRIPTION
What I'm doing:

Updating client with get and adding artifact type module needed for artifact types list endpoint
What it looks like:

```
## Returns
  {:ok, %{status: "ok", response: %{ "artifact_types": [
            {
                "slug": "story",
                "name": "Story",
                "description": "This is a story"
            }
  ]}}}
  """
  def list_artifact_types(config) do
    ArtifactType.list(config)
  end
```

What I'd like feedback on:

Anything you can think of, let me know if you have any questions!