### PR TITLE
#13 Create Streaming

### DIFF
--- a/lib/prodops/artifact.ex
+++ b/lib/prodops/artifact.ex
@@ -196,4 +196,33 @@ defmodule ProdopsEx.Artifact do
     endpoint = url(config) <> "/#{artifact_slug}/artifacts/#{artifact_id}/refine_stream"
     Client.api_post(endpoint, params, config)
   end
+
+  @doc """
+  Creates an artifact by submitting a request with the required parameters.
+
+  ## Parameters
+
+  - `params`: The parameters for the artifact creation request.
+  - `config`: The configuration map containing the API key and endpoint URL.
+
+  ## Example
+
+      iex> ProdopsEx.Artifact.stream_create_artifact(%{
+      ...>   prompt_template_id: 2,
+      ...>   project_id: 1,
+      ...>   artifact_slug: "story",
+      ...>   inputs: [
+      ...>     %{name: "Context", value: "this is a test"}
+      ...>   ]
+      ...> })
+  """
+  @spec stream_create_artifact(map, Keyword.t()) :: {:ok, map} | {:error, any}
+  def stream_create_artifact(params, config \\ []) do
+    config = Config.resolve_config(config)
+    %{artifact_slug: artifact_slug, prompt_template_id: prompt_template_id, project_id: project_id} = params
+    endpoint = url(config) <> "/#{artifact_slug}/artifacts/stream?project_id=#{project_id}"
+    inputs = Map.get(params, :inputs, [])
+    body = %{prompt_template_id: prompt_template_id, inputs: inputs, stream: true}
+    Client.api_post(endpoint, body, config)
+  end
 end

--- a/lib/prodops/artifact.ex
+++ b/lib/prodops/artifact.ex
@@ -192,9 +192,10 @@ defmodule ProdopsEx.Artifact do
   @spec stream_refine_artifact(map, Keyword.t()) :: {:ok, map} | {:error, any}
   def stream_refine_artifact(params, config \\ []) do
     config = Config.resolve_config(config)
-    %{artifact_slug: artifact_slug, artifact_id: artifact_id} = params
+    %{artifact_slug: artifact_slug, artifact_id: artifact_id, refine_prompt: refine_prompt} = params
     endpoint = url(config) <> "/#{artifact_slug}/artifacts/#{artifact_id}/refine_stream"
-    Client.api_post(endpoint, params, config)
+    body = %{artifact_slug: artifact_slug, artifact_id: artifact_id, refine_prompt: refine_prompt, stream: true}
+    Client.api_post(endpoint, body, config)
   end
 
   @doc """


### PR DESCRIPTION
What I'm doing:
- support create_stream endpoint

What it looks like:
```
iex(1)> result = ProdopsEx.Artifact.stream_create_artifact(%{artifact_slug: "story", prompt_template_id: 4, project_id: 1, inputs: [%{name: "Input", value: "Value"}]})

iex(2)> Enum.to_list(result)
["", "Once", " in", " the", " land", " of", " Ful", "gor", "ia", ",", " there",
 " existed", " an", " invisible", " force", " known", " only", " as", " Value",
 ".", " Unlike", " the", " g", "listening", " gold", " or", " the", " shimmer",
 "ing", " silver", " that", " people", " ho", "arded", " with", " ferv", "or",
 ",", " Value", " was", " indef", "in", "able", ",", " am", "orph", "ous", ",",
 " and", " yet", ...]
```


What I'd like feedback on/What I'm still working on while this is WIP:
- There's some kind of synchronicity issue where if I remove the IO.inspect in stream.ex, it fails to stream any of the response
- Can clean up the stream param/endpoint wrapper in general. If I leave the param it might not even need be its own function
