### PR TITLE
Allow publishing to Hex

### DIFF
--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -37,9 +37,11 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Check formatting
+        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix format --check-formatted
 
       - name: Check function specs with Dialyzer
+        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix dialyzer
 
       - name: Run tests

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -14,8 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "24"
-            elixir: "1.12"
           - otp: "26"
             elixir: "1.16"
     steps:
@@ -37,11 +35,9 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Check formatting
-        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix format --check-formatted
 
       - name: Check function specs with Dialyzer
-        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix dialyzer
 
       - name: Run tests

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -13,8 +13,11 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        otp: ["22.0"]
-        elixir: ["1.12.3"]
+        include:
+          - otp: "24"
+            elixir: "1.12"
+          - otp: "26"
+            elixir: "1.16"
     steps:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
-    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    name: Publish to Hex
     env:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
       MIX_ENV: test

--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -1,0 +1,46 @@
+name: Publish to Hex
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
+    env:
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+      MIX_ENV: test
+    strategy:
+      matrix:
+        otp: ["22.0"]
+        elixir: ["1.12.3"]
+    steps:
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # We want to use the newest deps here, since library users will not be
+      # locked to our mix.lock versions
+      - name: Install dependencies
+        run: mix deps.unlock --all && mix deps.get
+
+      - name: Compile and fail on warnings
+        run: mix compile --warnings-as-errors
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Check function specs with Dialyzer
+        run: mix dialyzer
+
+      - name: Run tests
+        run: mix test
+
+      - name: Publish to Hex
+        run: mix hex.publish --yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,18 +38,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.cache-name }}-
 
-      - name: Cache compiled build
-        id: cache-build
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-compiled-build
-        with:
-          path: _build
-          key: ${{ runner.os }}-mix-${{ env.cache-name }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-${{ env.cache-name }}-
-            ${{ runner.os }}-mix-
-
       - name: Install dependencies
         run: mix deps.get
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,11 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        otp: ["22.0"]
-        elixir: ["1.12.3"]
+        include:
+          - otp: "24"
+            elixir: "1.12"
+          - otp: "26"
+            elixir: "1.16"
     steps:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Check formatting
+        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix format --check-formatted
 
       - name: Cache PLT files for Dialyzer
@@ -70,6 +71,7 @@ jobs:
             plt-cache-
 
       - name: Check function specs with Dialyzer
+        if: matrix.elixir == '1.16' && matrix.otp == '26'
         run: mix dialyzer
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
       MIX_ENV: test
     strategy:
       matrix:
-        otp: ["26.2"]
-        elixir: ["1.16.2"]
+        otp: ["22.0"]
+        elixir: ["1.12.3"]
     steps:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.cache-name }}-
 
+      - name: Cache compiled build
+        id: cache-build
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-compiled-build
+        with:
+          path: _build
+          key: ${{ runner.os }}-mix-${{ env.cache-name }}-elixir-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.cache-name }}-elixir-${{ matrix.elixir }}-
+            ${{ runner.os }}-mix-${{ matrix.elixir }}-
+
       - name: Install dependencies
         run: mix deps.get
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,29 @@ to get started. Copy `config/config.example-secret.exs` to
 
 ## Development Setup
 
-1. Make sure you have Elixir 1.16+ installed
+1. Make sure you have Elixir 1.12+ installed
 1. Clone the repo
 1. Run `mix deps.get`
 1. Run `mix test`
 
+You can run the same checks that are in the CI pipeline, which is run via GitHub Actions:
+
+```
+./presubmit.sh
+```
+
+For convenience we recommend using this as a pre-push hook:
+
+```
+cp presubmit.sh .git/hooks/pre-push
+```
+
 ## Submitting Changes
 
+1. Find or open an Issue related to the changes you're making
 1. Fork the project
 1. Create a new topic branch to contain your feature, change, or fix.
-1. Make sure all the tests are still passing.
+1. Make sure all the checks are still passing: the CI system runs these checks automatically
 1. Implement your feature, change, or fix. Make sure to write tests, update and/or add documentation.
 1. Push your topic branch up to your fork.
-1. Open a Pull Request with a clear title and description.
+1. Open a Pull Request with a clear title and description, and mention the related Issue(s)

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,8 @@ defmodule ProdopsEx.MixProject do
   def project do
     [
       app: :prodops_ex,
+      description: "An SDK for interacting with the ProdOps API",
+      license: "MIT",
       version: "0.1.0",
       elixir: "~> 1.16",
       deps: deps(),
@@ -13,6 +15,7 @@ defmodule ProdopsEx.MixProject do
       # Docs
       name: "ProdopsEx",
       source_url: "https://github.com/revelrylabs/prodops_ex",
+      homepage_url: "https://prodops.ai",
       docs: [
         main: "readme",
         logo: "prodops-logo.png",

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule ProdopsEx.MixProject do
       description: "An SDK for interacting with the ProdOps API",
       license: "MIT",
       version: "0.1.0",
-      elixir: "~> 1.16",
+      elixir: "~> 1.12",
       deps: deps(),
       compilers: [:yecc, :leex] ++ Mix.compilers(),
       aliases: aliases(),

--- a/presubmit.sh
+++ b/presubmit.sh
@@ -1,0 +1,32 @@
+echo "Running pre-push checks (skip with --no-verify)..."
+
+interrupt() {
+  echo "\n"
+  echo "Trapped the INT signal, exiting..."
+  # https://tldp.org/LDP/abs/html/exitcodes.html
+  exit 130
+}
+
+print_skip_message() {
+  echo "\n"
+  echo "Checks failed, see above. You can skip them by running git push --no-verify."
+}
+
+trap interrupt INT
+# Ensure the skip message is printed when the script exits
+trap '[[ $? -ne 0 ]] && print_skip_message' EXIT
+
+mix format --check-formatted
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+mix dialyzer
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+mix test
+if [ $? -ne 0 ]; then
+  exit 1
+fi

--- a/test/prodops_ex/artifact_test.exs
+++ b/test/prodops_ex/artifact_test.exs
@@ -93,7 +93,7 @@ defmodule ProdopsEx.ArtifactTest do
   describe "stream_refine_artifact/2" do
     test "streams refinement of an artifact by submitting a request with the required parameters" do
       config = [api_url: "https://api.example.com", api_key: "secret_key"]
-      params = %{artifact_id: 1, artifact_slug: "story"}
+      params = %{stream: true, artifact_id: 1, artifact_slug: "story", refine_prompt: "refine prompt"}
       full_url = "#{config[:api_url]}/api/v1/artifact_types/story/artifacts/1/refine_stream"
 
       response = {:ok, %{"status" => "ok", "response" => %{"message" => "Artifact stream refined successfully."}}}


### PR DESCRIPTION
This _should_ deploy a new version to Hex when we create a release via GitHub, and also introduces testing back to Elixir version 1.12/OTP24.

Also includes a script to run the CI checks locally, and instructions on how to make it run automatically pre-push.

Minor documentation updates to specify we want PRs linked to an Issue.